### PR TITLE
[RA-6886] Cannot read xattr for root directory

### DIFF
--- a/xattrs.c
+++ b/xattrs.c
@@ -165,7 +165,7 @@ static ssize_t get_xattr_names(const char *fname)
 			rsyserr(FERROR_XFER, errno,
 				"get_xattr_names: llistxattr(%s,%s) failed",
 				full_fname(fname), big_num(arg));
-			return -1;
+			return strcmp(fname, ".") == 0 ? 0 : -1;
 		}
 		list_len = sys_llistxattr(fname, NULL, 0);
 		if (list_len < 0) {


### PR DESCRIPTION
Sometimes CIFS returned errors:
Ubuntu 22.04, kernel 6.2.0-39-generic: `llistxattr("<dst_dir>/.",1024) failed: Permission denied (13)`
Redhat-7.6-3.10-01, kernel 6.8.0-87-generic:  `llistxattr("<dst_dir>/.",1024) failed: No data available (61)`